### PR TITLE
Make `confirm` a predicate

### DIFF
--- a/browser_extension.js
+++ b/browser_extension.js
@@ -33,7 +33,7 @@
     var descriptor = {
         blocks: [
             [' ', 'alert %s', 'alert', ''],
-            ['r', 'confirm %s', 'confirm', 'Are you sure?'],
+            ['b', 'confirm %s', 'confirm', 'Are you sure?'],
             ['r', 'ask %s', 'ask', 'How are you?'],
             [' ', 'set window title to %s', 'setTitle', 'title'],
             [' ', 'open tab with %s', 'openTab', 'https://twitter.com/scratchteam']


### PR DESCRIPTION
This block reports a true/false value, so it should be a predicate.
